### PR TITLE
Fix python-oas version constraint

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ package_dir =
     = src
 install_requires =
     falcon >= 1.4, < 3
-    oas ~= 0.2
+    oas ~= 0.2.0
     six ~= 1.11
 
 [options.extras_require]


### PR DESCRIPTION
#31 updated the `oas` version constraint from `~=0.1.0` to `~=0.2`, but it should be `~=0.2.0`. The [PEP 440 compatible release clause](https://www.python.org/dev/peps/pep-0440/#compatible-release) for `~=0.2` means `>= 0.2, == 0.*` which differs from the previous version constraint (`~=0.1.0 -> >= 0.1.0, == 0.1.*`) and is likely unintended because a minor version update for versions `0.Y.Z` can contain breaking changes according to semantic versioning.